### PR TITLE
Optimize Ubuntu Dockerfile

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -25,5 +25,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor \
 
 ADD https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb /home/
 RUN dpkg -i /home/pandoc-1.19.2.1-1-amd64.deb
+RUN rm /home/pandoc-1.19.2.1-1-amd64.deb
 
 RUN pip install uwsgi


### PR DESCRIPTION
Remove .deb file after installation. This will reduce the size of the image.

Also, for consistency, a newline is added to the end of the file.